### PR TITLE
Adding EFS functionality for ec2 backed Jenkins master

### DIFF
--- a/cdk/docker/master/Dockerfile
+++ b/cdk/docker/master/Dockerfile
@@ -4,8 +4,8 @@ FROM jenkins/jenkins:lts
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 
-COPY modify_casc.py /var/jenkins_home/modify_casc.py
-COPY config-as-code.j2 /var/jenkins_home/config-as-code.j2
+COPY modify_casc.py /modify_casc.py
+COPY config-as-code.j2 /config-as-code.j2
 
 USER root
 
@@ -13,7 +13,9 @@ RUN apt-get update &&\
     apt-get install -y python-pip &&\
     pip install jinja2 dnspython &&\
     rm -rf /var/lib/apt/lists/* &&\
-    sed -i '/\/bin\/bash*/a \\n\/var\/jenkins_home\/modify_casc.py' /usr/local/bin/jenkins.sh
+    touch /config-as-code.yaml &&\
+    chown jenkins: /config-as-code.yaml &&\
+    sed -i '/\/bin\/bash*/a \\n\/modify_casc.py' /usr/local/bin/jenkins.sh
 
 # User back to jenkins
 USER jenkins

--- a/cdk/docker/master/modify_casc.py
+++ b/cdk/docker/master/modify_casc.py
@@ -7,8 +7,8 @@ from os import getenv
 def main():
     # This value comes as a build env var: `SSM_CONFIG_PARAM_NAME`
     _env = Environment(loader=FileSystemLoader('/'))
-    _template = _env.get_template("/var/jenkins_home/config-as-code.j2")
-    _config_file = open("/var/jenkins_home/config-as-code.yaml", "w")
+    _template = _env.get_template("/config-as-code.j2")
+    _config_file = open("/config-as-code.yaml", "w")
 
     _config_file.write((_template.render(
         ECS_CLUSTER_ARN=getenv('cluster_arn'),

--- a/cdk/jenkins/ecs.py
+++ b/cdk/jenkins/ecs.py
@@ -1,7 +1,11 @@
 from aws_cdk import (
     aws_ecs,
+    aws_ec2,
+    aws_efs,
     core
 )
+
+from os import getenv
 
 
 class ECSCluster(core.Stack):
@@ -17,4 +21,49 @@ class ECSCluster(core.Stack):
             vpc=self.vpc,
             default_cloud_map_namespace=aws_ecs.CloudMapNamespaceOptions(name=service_discovery_namespace)
         )
+
+        if getenv('EC2_ENABLED'):
+            self.asg = self.cluster.add_capacity(
+                "Ec2",
+                instance_type=aws_ec2.InstanceType("t3.xlarge"),
+                key_name="jenkinsonaws",
+            )
+
+            self.efs_sec_grp = aws_ec2.SecurityGroup(
+                 self, "EFSSecGrp",
+                 vpc=self.vpc,
+                 allow_all_outbound=True,
+            )
+
+            self.efs_sec_grp.add_ingress_rule(
+                peer=self.cluster.connections.security_groups[0],
+                connection=aws_ec2.Port(protocol=aws_ec2.Protocol.ALL,string_representation="ALL",from_port=2049,to_port=2049),
+                description="EFS"
+            )
+
+            self.efs_filesystem = aws_efs.CfnFileSystem(
+                self, "EFSBackend",
+            )
+
+            counter = 0
+            for subnet in self.vpc.private_subnets:
+                aws_efs.CfnMountTarget(
+                    self, "EFS{}".format(counter),
+                    file_system_id=self.efs_filesystem.ref,
+                    subnet_id=subnet.subnet_id,
+                    security_groups=[
+                        self.efs_sec_grp.security_group_id
+                    ]
+                )
+                counter += 1
+
+            self.user_data = """
+                sudo yum install -y amazon-efs-utils 
+                sudo mkdir /mnt/efs
+                sudo chown -R ec2-user: /mnt/efs
+                sudo chmod -R 0777 /mnt/efs
+                sudo mount -t efs -o tls /mnt/efs {}:/ efs
+                """.format(self.efs_filesystem.ref)
+
+            self.asg.add_user_data(self.user_data)
 

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -2,3 +2,8 @@ aws-cdk.core
 aws-cdk.aws_ecs
 aws-cdk.aws_ecs_patterns
 aws-cdk.aws_elasticloadbalancingv2
+aws-cdk.aws_efs
+aws-cdk.aws_iam
+aws-cdk.aws_servicediscovery
+aws-cdk.aws_ecr
+aws-cdk.aws_ecr_assets


### PR DESCRIPTION
When enabling EC2 as the compute backend, EFS will be enabled to store state of the jenkins master. This means job history will be preserved if the container is replaced.