### PR TITLE
Pinned new plugins version to be compatible with the used jenkins image

### DIFF
--- a/cdk/docker/leader/Dockerfile
+++ b/cdk/docker/leader/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.235.2-lts
+FROM jenkins/jenkins:2.235.5-lts
 
 # Install custom plugins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt

--- a/cdk/docker/leader/plugins.txt
+++ b/cdk/docker/leader/plugins.txt
@@ -1,4 +1,4 @@
-amazon-ecs:1.36
-blueocean:1.23.2
-pipeline-cloudwatch-logs:0.1
-configuration-as-code:1.41
+amazon-ecs:1.37
+blueocean:1.24.7
+pipeline-cloudwatch-logs:0.2
+configuration-as-code:1.51


### PR DESCRIPTION
Plugins versions are not compatible with the used jenkins image

Updated plugins versions and jenkins image so they asre compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
