### PR TITLE
fix all for 2.361 release and new plugins

### DIFF
--- a/cdk/docker/leader/Dockerfile
+++ b/cdk/docker/leader/Dockerfile
@@ -1,8 +1,10 @@
-FROM jenkins/jenkins:2.235.5-lts
+FROM jenkins/jenkins:2.361.4-lts
 
 # Install custom plugins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+# Use built-in plugin tool to manage plugins
+RUN jenkins-plugin-cli --plugins -f /usr/share/jenkins/ref/plugins.txt
+
 
 COPY modify_casc.py /modify_casc.py
 COPY config-as-code.j2 /config-as-code.j2
@@ -10,7 +12,7 @@ COPY config-as-code.j2 /config-as-code.j2
 USER root
 
 RUN apt-get update &&\
-    apt-get install -y python-pip &&\
+    apt-get install -y python3-pip &&\
     pip install jinja2 dnspython &&\
     rm -rf /var/lib/apt/lists/* &&\
     touch /config-as-code.yaml &&\

--- a/cdk/docker/leader/config-as-code.j2
+++ b/cdk/docker/leader/config-as-code.j2
@@ -1,4 +1,5 @@
 jenkins:
+  mode: EXCLUSIVE # CHANGE: encourage jobs to run on workers
   clouds:
     - ecs:
         cluster: {{ECS_CLUSTER_ARN}}
@@ -6,12 +7,13 @@ jenkins:
         credentialsId: False
         regionName: {{AWS_REGION}}
         name: fargate-workers
+        numExecutors: 1 # FIX: https://github.com/jenkinsci/amazon-ecs-plugin/issues/291
         jenkinsUrl: {{JENKINS_URL}}
         templates:
           - label: fargate-workers
             templateName: fargate-worker-nodes
             # Build image and store in ECR. Benefits: fast download time, control image on your own
-            image: jenkins/jnlp-slave
+            image: jenkins/jnlp-slave:latest-jdk11 # FIX: prevent 52.0 not match 55.0 error
             launchType: FARGATE
             networkMode: awsvpc
             # Soft memory limit
@@ -29,4 +31,7 @@ jenkins:
                 value: {{LOG_GROUP}}
               - name: awslogs-stream-prefix
                 value: {{LOG_STREAM_PREFIX}}
+aws:
+  cloudWatchLogs:
+    logGroupName: {{LOG_GROUP}} # FIX: needs log group to launch workers
 

--- a/cdk/docker/leader/modify_casc.py
+++ b/cdk/docker/leader/modify_casc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from jinja2 import Environment, FileSystemLoader
 from os import getenv

--- a/cdk/docker/leader/plugins.txt
+++ b/cdk/docker/leader/plugins.txt
@@ -1,4 +1,5 @@
-amazon-ecs:1.37
-blueocean:1.24.7
+# update: 2.361.4 matching plugins
+amazon-ecs:1.46
+blueocean: 1.25.8
 pipeline-cloudwatch-logs:0.2
-configuration-as-code:1.51
+configuration-as-code:1569.vb_72405b_80249

--- a/cdk/jenkins/jenkins_leader.py
+++ b/cdk/jenkins/jenkins_leader.py
@@ -111,7 +111,7 @@ class JenkinsLeader(core.Stack):
                 },
                 logging=ecs.LogDriver.aws_logs(
                     stream_prefix="Jenkinsleader",
-                    log_retention=logs.RetentionDays.ONE_WEEK
+                    retention=logs.RetentionDays.ONE_WEEK # BUG: defaulting to 'never'
                 ),
             )
 
@@ -190,7 +190,12 @@ class JenkinsLeader(core.Stack):
                     "ecs:DescribeContainerInstances",
                     "ecs:ListTaskDefinitions",
                     "ecs:DescribeTaskDefinition",
-                    "ecs:DescribeTasks"
+                    "ecs:DescribeTasks",
+                    "logs:DescribeLogStreams",
+                    "logs:CreateLogStream",
+                    "logs:FilterLogEvents",
+                    "logs:PutLogEvents",
+                    "logs:GetLogEvents"
                 ],
                 resources=[
                     "*"
@@ -212,7 +217,8 @@ class JenkinsLeader(core.Stack):
         self.jenkins_leader_task.add_to_task_role_policy(
             iam.PolicyStatement(
                 actions=[
-                    "ecs:RunTask"
+                    "ecs:RunTask",
+                    "ecs:ListTagsForResource"
                 ],
                 resources=[
                     "arn:aws:ecs:{0}:{1}:task-definition/fargate-workers*".format(


### PR DESCRIPTION
*Issue #, if available:*

Current jenkins-on-aws is over a year out of date and did not work out of the box when I tried to run it. Updated to latest LTS Jenkins 2.361 and found matching plugin sets. Updated various config files for the plugins so that everything works.

*Description of changes:*

* Update to 2.361 (Nov 2022)
* Update plugin versions to match
* Use new `jenkins-plugin-cli` to install plugins
* Switch to python3
* Fix empty log group for cloudwatch plugin
* Add new IAM permissions needed by ECS plugin
* Update jcasc properties to match new plugins and work around some bugs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
